### PR TITLE
Refine sparkle trail and add cursor sway

### DIFF
--- a/bunny_overlay.py
+++ b/bunny_overlay.py
@@ -1,9 +1,12 @@
 import sys
-import pyautogui
 import time
 import math
 import random
 from PySide6 import QtCore, QtGui, QtWidgets
+
+# Overlay offset relative to the cursor
+OFFSET_X = 30
+OFFSET_Y = 0
 
 
 class Sparkle(QtWidgets.QLabel):
@@ -11,11 +14,14 @@ class Sparkle(QtWidgets.QLabel):
         super().__init__(parent)
         self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
         self.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
-        self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.Tool)
+        self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
 
-        pixmap = QtGui.QPixmap("stars.png").scaled(40, 40, QtCore.Qt.KeepAspectRatio,
-                                                     QtCore.Qt.SmoothTransformation)
-        self.setPixmap(pixmap)
+        if not hasattr(Sparkle, "_pixmap"):
+            Sparkle._pixmap = QtGui.QPixmap("stars.png").scaled(
+                40, 40, QtCore.Qt.KeepAspectRatio,
+                QtCore.Qt.SmoothTransformation
+            )
+        self.setPixmap(Sparkle._pixmap)
         self.move(x, y)
         self.opacity = 1.0
 
@@ -77,44 +83,74 @@ class BunnyOverlay(QtWidgets.QWidget):
             90, 90, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation
         )
         self.label.setPixmap(self.base_pixmap)
+        self.pixmap_cache = {}
+        # overlay offset from cursor
+        self.offset_x = OFFSET_X
+        self.offset_y = OFFSET_Y
 
         # Mouse tracking state
-        start_pos = pyautogui.position()
-        self.current_x = start_pos.x
-        self.current_y = start_pos.y
+        start_pos = QtGui.QCursor.pos()
+        self.current_x = start_pos.x()
+        self.current_y = start_pos.y()
         self.current_angle = 0
 
         self.trail_timer = QtCore.QTimer()
         self.trail_timer.timeout.connect(self.spawn_trail)
         self.trail_timer.start(80)
 
+        # Track previous mouse position for sway effect
+        self.prev_mouse_x = self.current_x
+        self.sway_offset = 0
+
         self.timer = QtCore.QTimer()
         self.timer.timeout.connect(self.update_position)
         self.timer.start(10)
 
     def spawn_trail(self):
-        x = self.x() + random.randint(20, 60)
-        y = self.y() + random.randint(20, 60)
+        """Spawn sparkle particles at the overlay's position."""
+        x = int(self.current_x - 20 + random.randint(-10, 10))
+        y = int(self.current_y - 20 + random.randint(-10, 10))
         self.sparkle_layer.add_sparkle(x, y)
 
     def update_position(self):
-        mouse_pos = pyautogui.position()
+        mouse_pos = QtGui.QCursor.pos()
+
+        # Horizontal sway based on mouse delta
+        dx_mouse = mouse_pos.x() - self.prev_mouse_x
+        self.prev_mouse_x = mouse_pos.x()
+        self.sway_offset += (dx_mouse - self.sway_offset) * 0.2
+        self.sway_offset = max(min(self.sway_offset, 20), -20)
+
+        target_x = mouse_pos.x() + self.offset_x + self.sway_offset
+        target_y = mouse_pos.y() + self.offset_y
 
         # Smooth toward cursor
         smoothing = 0.15
-        self.current_x += (mouse_pos.x - self.current_x) * smoothing
-        self.current_y += (mouse_pos.y - self.current_y) * smoothing
+        self.current_x += (target_x - self.current_x) * smoothing
+        self.current_y += (target_y - self.current_y) * smoothing
+
+        dx_lim = self.current_x - mouse_pos.x()
+        dy_lim = self.current_y - mouse_pos.y()
+        dist = math.hypot(dx_lim, dy_lim)
+        if dist > 50:
+            factor = 50.0 / dist
+            self.current_x = mouse_pos.x() + dx_lim * factor
+            self.current_y = mouse_pos.y() + dy_lim * factor
 
         # Rotation based on smoothed horizontal movement
-        dx = mouse_pos.x - self.current_x
+        dx = mouse_pos.x() - self.current_x
         target_angle = max(min(dx * 2, 15), -15)
         self.current_angle += (target_angle - self.current_angle) * 0.2
 
         # Rotate and draw bunny into fixed-size canvas
-        rotated_pixmap = self.base_pixmap.transformed(
-            QtGui.QTransform().rotate(self.current_angle),
-            QtCore.Qt.SmoothTransformation
-        )
+        angle_key = int(round(self.current_angle))
+        rotated_pixmap = self.pixmap_cache.get(angle_key)
+        if rotated_pixmap is None:
+            rotated_pixmap = self.base_pixmap.transformed(
+                QtGui.QTransform().rotate(angle_key),
+                QtCore.Qt.SmoothTransformation
+            )
+            self.pixmap_cache[angle_key] = rotated_pixmap
 
         canvas = QtGui.QPixmap(90, 90)
         canvas.fill(QtCore.Qt.transparent)
@@ -142,5 +178,7 @@ if __name__ == "__main__":
     sparkle_layer = SparkleLayer()
     overlay = BunnyOverlay("hachiware.png", sparkle_layer)
     overlay.show()
+    overlay.raise_()
+    sparkle_layer.lower()
 
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- add mouse-based sway when updating overlay position
- spawn sparkles at the overlay so they trail behind

## Testing
- `python3 -m py_compile bunny_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_684b43edcb58832aa0457d20366b2132